### PR TITLE
Add method to set individual particle macrosizes

### DIFF
--- a/orbit_tools/bunch.py
+++ b/orbit_tools/bunch.py
@@ -18,6 +18,14 @@ from orbit.utils.consts import charge_electron
 from .cov import normalization_matrix
 
 
+def set_particle_macrosizes(bunch: Bunch, macrosizes: Iterable) -> Bunch:
+    bunch.addPartAttr("macrosize")  # sets macrosize=0 for all particles
+    attribute_array_index = 0
+    for index in range(bunch.getSize()):
+        bunch.partAttrValue("macrosize", index, attribute_array_index, macrosizes[index])
+    return bunch
+
+
 def get_part_coords(bunch: Bunch, index: int) -> list[float]:
     x = bunch.x(index)
     y = bunch.y(index)

--- a/tests/test_bunch.py
+++ b/tests/test_bunch.py
@@ -126,3 +126,12 @@ def test_generate_bunch():
 def test_get_bunch_twiss_containers():
     bunch = make_gaussian_bunch()
     twiss_x, twiss_y, twiss_z = ot.bunch.get_bunch_twiss_containers(bunch)
+    
+
+def test_set_particle_macrosizes():
+    bunch = make_gaussian_bunch()
+    macrosizes = list(range(bunch.getSize()))
+    bunch = ot.bunch.set_particle_macrosizes(bunch, macrosizes)
+    for i, macrosize in enumerate(macrosizes):
+        assert macrosize == bunch.partAttrValue("macrosize", i, 0) 
+


### PR DESCRIPTION
The primary use is to set some particles to zero macro size so that they do not contribute to the self-generated electric field. Example here: https://github.com/austin-hoover/pyorbit-scripts/tree/main/macrosize.